### PR TITLE
move AGENTSEA_HOME to ~/.agentsea by default

### DIFF
--- a/agentdesk/cli/main.py
+++ b/agentdesk/cli/main.py
@@ -335,9 +335,11 @@ def export_keypair(
         )  # Set file mode to read/write for the owner, and read for others
 
         print(
-            f"Decrypted private key for device '{key.name}' saved to {private_key_file_name}"
+            f"Decrypted private key for device '{key.name}' saved to {os.path.abspath(private_key_file_name)}"
         )
-        print(f"Public key for device '{key.name}' saved to {public_key_file_name}")
+        print(
+            f"Public key for device '{key.name}' saved to {os.path.abspath(public_key_file_name)}"
+        )
 
 
 @app.command(

--- a/agentdesk/db/conn.py
+++ b/agentdesk/db/conn.py
@@ -40,11 +40,16 @@ def get_pg_conn() -> Engine:
 
 def get_sqlite_conn() -> Engine:
     db_name = os.environ.get("DESKS_DB_NAME", "desks.db")
-    db_path = os.environ.get("DESKS_DB_PATH", "./.data")
-    db_test = os.environ.get("DESKS_DB_TEST", "false") == "true"
+    agentsea_home_path = os.path.expanduser(
+        os.environ.get("AGENTSEA_HOME", "~/.agentsea")
+    )
+    db_path = os.path.expanduser(
+        os.environ.get("AGENTSEA_DB_DIR", os.path.join(agentsea_home_path, "data"))
+    )
+    db_test = os.environ.get("AGENTSEA_DB_TEST", "false") == "true"
     if db_test:
         db_name = f"desk_test_{int(time.time())}.db"
-    logger.debug(f"connecting to local sqlite db ./.data/{db_name}")
+    logger.debug(f"connecting to local sqlite db {db_path}/{db_name}")
     os.makedirs(os.path.dirname(f"{db_path}/{db_name}"), exist_ok=True)
     engine = create_engine(f"sqlite:///{db_path}/{db_name}")
     return engine


### PR DESCRIPTION
- AGENTSEA_DB_DIR can override the data dir
- Added full path to show exactly where keys are written

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - `export_keypair` function now provides the absolute path when saving keys, making it easier to locate saved key files.

- **Improvements**
  - Improved handling of database paths with new environment variables for better configuration flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->