### PR TITLE
Fix img project gce and add dev mode

### DIFF
--- a/agentdesk/cli/main.py
+++ b/agentdesk/cli/main.py
@@ -280,7 +280,7 @@ def clear_cache():
 # START Dev mode commands
 @app.command(
     name="export-keypair",
-    help="Dev mode: Export the decrypted private key and public key for a device.",
+    help="Export the decrypted private key and public key for a device. Requires dev mode enabled.",
 )
 def export_keypair(
     name: str = typer.Argument(
@@ -343,7 +343,8 @@ def export_keypair(
 
 
 @app.command(
-    name="list-keys", help="Dev mode: List all SSH keys stored in the local database."
+    name="list-keys",
+    help="List all SSH keys stored in the local database. Requires dev mode enabled.",
 )
 def list_keys():
     if not dev_mode:

--- a/agentdesk/vm/gce.py
+++ b/agentdesk/vm/gce.py
@@ -72,15 +72,17 @@ class GCEProvider(DesktopProvider):
 
         images_client = compute_v1.ImagesClient(credentials=self.credentials)
 
+        # Ensure the image_project_id is set to the correct public project
+        image_project_id = "agentsea-dev"
+        source_image_url = f"projects/{image_project_id}/global/images/{image}"
+
         # Check if the image exists
-        img = images_client.get(project=self.project_id, image=image)
+        img = images_client.get(project=image_project_id, image=image)
         if img.status != "READY":
             raise ValueError("Image is not ready")
 
         instance_client = compute_v1.InstancesClient(credentials=self.credentials)
         machine_type = f"zones/{self.zone}/machineTypes/custom-{cpu}-{memory * 1024}"
-        image_project_id = "agentsea-dev"
-        source_image_url = f"projects/{image_project_id}/global/images/{image}"
 
         disk_config = compute_v1.AttachedDiskInitializeParams(
             disk_size_gb=int(disk[:-2]), source_image=source_image_url

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "agentdesk"
-version = "0.2.71"
+version = "0.2.72"
 description = "A desktop for AI agents"
 authors = ["Patrick Barker <patrickbarkerco@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated help messages for `export-keypair` and `list-keys` commands to indicate that dev mode must be enabled.

- **Improvements**
  - Ensured `image_project_id` points to the correct public project for better accuracy.

- **Version Updates**
  - Project version updated from 0.2.71 to 0.2.72.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->